### PR TITLE
escape archive name

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -73,7 +73,7 @@ export const writeFileHeaders = ({
     );
   } else {
     res.writeHead(200, {
-      [ContentHeaders.DISPOSITION]: `${ContentDispositionPrefix}"${fileName}${extension}"`,
+      [ContentHeaders.DISPOSITION]: `${ContentDispositionPrefix}"${encodeURI(fileName)}${extension}"`,
       [ContentHeaders.TYPE]: contentType,
     });
   }


### PR DESCRIPTION
escape archive name which is set as the content-disposition-header