### PR TITLE
feature: download DataCanvas as ZIP

### DIFF
--- a/src/_constants.ts
+++ b/src/_constants.ts
@@ -8,6 +8,8 @@ export const API_URL = process.env.API_URL ?? 'https://api.pennsieve.net';
 
 export const PACKAGES_PATH = process.env.PACKAGES_PATH ?? '/packages';
 
+export const DATACANVAS_PATH = process.env.DATACANVAS_PATH ?? '/datacanvas';
+
 export const MANIFEST_PATH = process.env.MANIFEST_PATH ?? '/download-manifest';
 
 export const MAX_ARCHIVE_SIZE = parseInt(

--- a/src/app/app.ts
+++ b/src/app/app.ts
@@ -1,6 +1,6 @@
 import express from 'express';
 import { errorMiddleware } from './error.middleware';
-import { validateApiRequest, validateDiscoverRequest } from './validators';
+import { validateApiRequest, validateDiscoverRequest, validateDataCanvasRequest } from './validators';
 import { downloadHandler } from './download.handler';
 
 export const app = express();
@@ -14,5 +14,7 @@ app.get('/health', (_, response) =>
 app.post('/', downloadHandler(validateApiRequest));
 
 app.post('/discover', downloadHandler(validateDiscoverRequest));
+
+app.post('/datacanvas', downloadHandler(validateDataCanvasRequest));
 
 app.use(errorMiddleware);


### PR DESCRIPTION
Add the `/datacanvas` endpoint to enable downloading a DataCanvas as a ZIP file. 